### PR TITLE
fix: replace deprecated  scale call with scaleTo

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,8 @@ var board = new five.Board().on("ready", function() {
     range: [0, 100]
   });
 
-  sensor.scale([0, 100]);
-
   sensor.on("data", function() {
-    graph.update(this.value);
+    graph.update(sensor.scaleTo([0, 100]););
   });
 });
 


### PR DESCRIPTION
reference

https://learn.sparkfun.com/tutorials/experiment-guide-for-the-johnny-five-inventors-kit/experiment-3-reading-a-potentiometer